### PR TITLE
Configure central-publishing-maven-plugin manually

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -703,12 +703,32 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>default-deploy</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <publishingServerId>central</publishingServerId>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>publish-to-central</id>
+                        <goals>
+                            <goal>publish</goal>
+                        </goals>
+                        <phase>deploy</phase>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
- **Console UI ListChoice's (relative)pageSize is never used, fixes #1034 (#1041)**
- **Add release workflow (#1047)**
- **Bump org.codehaus.mojo:exec-maven-plugin from 3.3.0 to 3.4.1 (#1054)**
- **Bump sshd.version from 2.13.1 to 2.13.2 (#1049)**
- **Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.7.0 to 3.8.0 (#1044)**
- **Bump org.apache.maven.plugins:maven-site-plugin (#1045)**
- **Bump org.easymock:easymock from 5.3.0 to 5.4.0 (#1050)**
- **Bump slf4j.version from 2.0.13 to 2.0.16 (#1057)**
- **Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.4 to 3.2.5 (#1058)**
- **Build update (#1055)**
- **Bump junit.version from 5.10.3 to 5.11.0 (#1059)**
- **Bump org.apache.maven.plugins:maven-install-plugin from 3.1.2 to 3.1.3 (#1061)**
- **Bump org.apache.maven.plugins:maven-surefire-plugin from 3.3.1 to 3.5.0 (#1065)**
- **Bump org.apache.maven.plugins:maven-dependency-plugin (#1064)**
- **Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.8.0 to 3.10.0 (#1066)**
- **Added possibility of cancelling prompts (#1046)**
- **Bump groovy.version from 4.0.22 to 4.0.23 (#1070)**
- **[consoleui] Make it easier to extend `ConsolePrompt` (#1068)**
- **fix typo: inMode -> outMode (#1075)**
- **Bump org.graalvm.sdk:graal-sdk from 24.0.2 to 24.1.0 (#1073)**
- **Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.5 to 3.2.6 (#1072)**
- **Bump net.java.dev.jna:jna from 5.14.0 to 5.15.0 (#1071)**
- **[maven-release-plugin] prepare release jline-3.27.0**
- **[maven-release-plugin] prepare for next development iteration**
- **Configure central-publishing-maven-plugin manually**
