### PR TITLE
Hexadecimal triple support in Jansi

### DIFF
--- a/jansi-core/src/main/java/org/jline/jansi/Ansi.java
+++ b/jansi-core/src/main/java/org/jline/jansi/Ansi.java
@@ -116,6 +116,7 @@ public class Ansi implements Appendable {
     /**
      * ED (Erase in Display) / EL (Erase in Line) parameter (see
      * <a href="https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_sequences">CSI sequence J and K</a>)
+     *
      * @see Ansi#eraseScreen(Erase)
      * @see Ansi#eraseLine(Erase)
      */
@@ -389,6 +390,15 @@ public class Ansi implements Appendable {
         return this;
     }
 
+    public Ansi fgRgb(String hex) {
+
+        if (hex.startsWith("#")) {
+            hex = hex.substring(1);
+        }
+
+        return fgRgb(Integer.parseInt(hex, 16));
+    }
+
     public Ansi fgRgb(int color) {
         return fgRgb(color >> 16, color >> 8, color);
     }
@@ -444,6 +454,15 @@ public class Ansi implements Appendable {
         attributeOptions.add(5);
         attributeOptions.add(color & 0xff);
         return this;
+    }
+
+    public Ansi bgRgb(String hex) {
+
+        if (hex.startsWith("#")) {
+            hex = hex.substring(1);
+        }
+
+        return bgRgb(Integer.parseInt(hex, 16));
     }
 
     public Ansi bgRgb(int color) {


### PR DESCRIPTION
- **Console UI ListChoice's (relative)pageSize is never used, fixes #1034 (#1041)**
- **Add release workflow (#1047)**
- **Bump org.codehaus.mojo:exec-maven-plugin from 3.3.0 to 3.4.1 (#1054)**
- **Bump sshd.version from 2.13.1 to 2.13.2 (#1049)**
- **Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.7.0 to 3.8.0 (#1044)**
- **Bump org.apache.maven.plugins:maven-site-plugin (#1045)**
- **Bump org.easymock:easymock from 5.3.0 to 5.4.0 (#1050)**
- **Bump slf4j.version from 2.0.13 to 2.0.16 (#1057)**
- **Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.4 to 3.2.5 (#1058)**
- **Build update (#1055)**
- **Bump junit.version from 5.10.3 to 5.11.0 (#1059)**
- **Bump org.apache.maven.plugins:maven-install-plugin from 3.1.2 to 3.1.3 (#1061)**
- **Bump org.apache.maven.plugins:maven-surefire-plugin from 3.3.1 to 3.5.0 (#1065)**
- **Bump org.apache.maven.plugins:maven-dependency-plugin (#1064)**
- **Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.8.0 to 3.10.0 (#1066)**
- **Added possibility of cancelling prompts (#1046)**
- **Bump groovy.version from 4.0.22 to 4.0.23 (#1070)**
- **[consoleui] Make it easier to extend `ConsolePrompt` (#1068)**
- **fix typo: inMode -> outMode (#1075)**
- **Bump org.graalvm.sdk:graal-sdk from 24.0.2 to 24.1.0 (#1073)**
- **Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.5 to 3.2.6 (#1072)**
- **Bump net.java.dev.jna:jna from 5.14.0 to 5.15.0 (#1071)**
- **[maven-release-plugin] prepare release jline-3.27.0**
- **[maven-release-plugin] prepare for next development iteration**
- **Configure central-publishing-maven-plugin manually (#1080)**
- **Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.6 to 3.2.7 (#1079)**
- **Bump com.mycila:license-maven-plugin from 4.5 to 4.6 (#1078)**
- **Bump junit.version from 5.11.0 to 5.11.1 (#1077)**
- **Bump org.sonatype.central:central-publishing-maven-plugin (#1076)**
- **Add tripleto hexadecimal color support**
