### PR TITLE
Fix ConsolePrompt.prompt() throwing IOError instead of UserInterruptedException

### DIFF
--- a/console-ui/src/main/java/org/jline/consoleui/prompt/ConsolePrompt.java
+++ b/console-ui/src/main/java/org/jline/consoleui/prompt/ConsolePrompt.java
@@ -8,7 +8,9 @@
  */
 package org.jline.consoleui.prompt;
 
+import java.io.IOError;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -19,6 +21,7 @@ import org.jline.consoleui.elements.items.impl.ChoiceItem;
 import org.jline.consoleui.prompt.AbstractPrompt.*;
 import org.jline.consoleui.prompt.builder.PromptBuilder;
 import org.jline.reader.LineReader;
+import org.jline.reader.UserInterruptException;
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Terminal;
 import org.jline.utils.*;
@@ -137,6 +140,12 @@ public class ConsolePrompt {
                 resultMap.put(pe.getName(), result);
             }
             return resultMap;
+        } catch (IOError e) {
+            if (e.getCause() instanceof InterruptedIOException) {
+                throw new UserInterruptException(e.getCause());
+            } else {
+                throw e;
+            }
         } finally {
             terminal.setAttributes(attributes);
             terminal.puts(InfoCmp.Capability.exit_ca_mode);

--- a/console/src/main/java/org/jline/widget/TailTipWidgets.java
+++ b/console/src/main/java/org/jline/widget/TailTipWidgets.java
@@ -202,7 +202,7 @@ public class TailTipWidgets extends Widgets {
      */
     public boolean tailtipComplete() {
         if (doTailTip(LineReader.EXPAND_OR_COMPLETE)) {
-            if (lastBinding().equals("\t")) {
+            if ("\t".equals(lastBinding())) {
                 callWidget(LineReader.BACKWARD_CHAR);
                 reader.runMacro(key(reader.getTerminal(), InfoCmp.Capability.key_right));
             }

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <gogo.jline.version>1.1.8</gogo.jline.version>
         <slf4j.version>2.0.16</slf4j.version>
         <findbugs.version>3.0.2</findbugs.version>
-        <groovy.version>4.0.23</groovy.version>
+        <groovy.version>4.0.24</groovy.version>
         <ivy.version>2.5.2</ivy.version>
         <graal.version>24.1.1</graal.version>
         <graal.plugin.version>21.2.0</graal.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <jansi.version>2.4.1</jansi.version>
         <juniversalchardet.version>1.0.3</juniversalchardet.version>
         <sshd.version>2.14.0</sshd.version>
-        <easymock.version>5.4.0</easymock.version>
+        <easymock.version>5.5.0</easymock.version>
         <junit.version>5.11.3</junit.version>
         <gogo.runtime.version>1.1.6</gogo.runtime.version>
         <gogo.jline.version>1.1.8</gogo.jline.version>

--- a/reader/src/main/java/org/jline/reader/UserInterruptException.java
+++ b/reader/src/main/java/org/jline/reader/UserInterruptException.java
@@ -19,6 +19,11 @@ public class UserInterruptException extends RuntimeException {
 
     private final String partialLine;
 
+    public UserInterruptException(Throwable cause) {
+        super(cause);
+        this.partialLine = null;
+    }
+
     public UserInterruptException(String partialLine) {
         this.partialLine = partialLine;
     }


### PR DESCRIPTION
- **Fix possible NPE in TailTipWidgets (#1108)**
- **Bump groovy.version from 4.0.23 to 4.0.24 (#1110)**
- **Bump org.easymock:easymock from 5.4.0 to 5.5.0 (#1113)**
- **Fix ConsolePrompt.prompt() throwing IOError instead of UserInterruptedException**
